### PR TITLE
Refactor to FastAPI service

### DIFF
--- a/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/requirements.txt
+++ b/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/requirements.txt
@@ -4,3 +4,5 @@ langchain-core
 sentence-transformers
 google-api-python-client
 requests
+fastapi
+uvicorn

--- a/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/api_server.py
+++ b/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/api_server.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+"""FastAPI service providing log analysis endpoints."""
+
+from typing import List
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from .log_processor import analyse_lines
+from .utils import save_state, STATE
+from .vector_db import VECTOR_DB
+
+app = FastAPI()
+
+
+class Logs(BaseModel):
+    logs: List[str]
+
+
+@app.post("/analyze/logs")
+async def analyze_logs(payload: Logs):
+    """Analyze a batch of log lines and return results."""
+    return analyse_lines(payload.logs)
+
+
+@app.on_event("shutdown")
+def _shutdown() -> None:
+    save_state(STATE)
+    VECTOR_DB.save()

--- a/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/log_processor.py
+++ b/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/log_processor.py
@@ -89,3 +89,9 @@ def process_logs(log_paths: List[Path]) -> List[Dict[str, Any]]:
         all_new_lines.extend(tail_since(p))
 
     return analyse_lines(all_new_lines)
+
+
+def process_log_lines(log_lines: List[str]) -> List[Dict[str, Any]]:
+    """Analyze already collected log lines."""
+
+    return analyse_lines(log_lines)

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@
 ## I. 系統架構 (概念流程)
 
 1. **Filebeat 近即時輸入：** Filebeat 監控日誌並將新行透過 HTTP 傳送至 `filebeat_server.py`，立即觸發後續分析。
-2. **批次日誌處理：** 亦可定期執行 `main.py`，程式會根據 `data/file_state.json` 記錄的偏移量只讀取新增內容。
-3. **Wazuh 告警比對：** 每行先送至 Wazuh `logtest` API，僅保留產生告警的項目並取得告警 JSON。
-4. **啟發式評分與取樣：** 對告警行以 `fast_score()` 計算分數，挑選最高分的前 `SAMPLE_TOP_PERCENT`％ 作為候選。
-5. **向量嵌入與歷史比對：** 將候選日誌嵌入向量並寫入 FAISS 索引，以便搜尋過往相似模式。
-6. **LLM 深度分析：** 把 Wazuh 告警 JSON 傳入 `llm_analyse()` 由 Gemini 分析是否為攻擊行為並回傳結構化結果。
-7. **結果輸出與成本控制：** 將分析結果寫入 `analysis_results.json`，同時更新向量索引、狀態檔並追蹤 LLM Token 成本。
+2. **FastAPI 服務：** 啟動 `api_server.py` 提供 `/analyze/logs` 端點。
+3. **批次日誌處理：** `main.py` 會讀取新行並呼叫前述 API 取得分析結果。
+4. **Wazuh 告警比對：** 每行先送至 Wazuh `logtest` API，僅保留產生告警的項目並取得告警 JSON。
+5. **啟發式評分與取樣：** 對告警行以 `fast_score()` 計算分數，挑選最高分的前 `SAMPLE_TOP_PERCENT`％ 作為候選。
+6. **向量嵌入與歷史比對：** 將候選日誌嵌入向量並寫入 FAISS 索引，以便搜尋過往相似模式。
+7. **LLM 深度分析：** 把 Wazuh 告警 JSON 傳入 `llm_analyse()` 由 Gemini 分析是否為攻擊行為並回傳結構化結果。
+8. **結果輸出與成本控制：** 將分析結果寫入 `analysis_results.json`，同時更新向量索引、狀態檔並追蹤 LLM Token 成本。
 
 ---
 


### PR DESCRIPTION
## Summary
- create FastAPI API server for log analysis
- allow log_processor to analyze lists of lines directly
- refactor main.py into an API client
- document new service and update instructions
- include FastAPI and uvicorn in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68457805dd9083209b52f3725c390304