### PR TITLE
Add tests for Wazuh API and LLM handler

### DIFF
--- a/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/tests/test_llm_handler.py
+++ b/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/tests/test_llm_handler.py
@@ -1,0 +1,64 @@
+import json
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from lms_log_analyzer.src import llm_handler
+from lms_log_analyzer import config
+
+class TestLLMHandler(unittest.TestCase):
+    def setUp(self):
+        self.orig_chain = llm_handler.LLM_CHAIN
+        self.orig_prompt = getattr(llm_handler, "PROMPT", None)
+        llm_handler.LLM_CHAIN = Mock()
+        llm_handler.PROMPT = SimpleNamespace(format=lambda **kw: "prompt")
+        llm_handler.CACHE.clear()
+        llm_handler.COST_TRACKER.cost_hourly = 0.0
+        llm_handler.COST_TRACKER.in_tokens_hourly = 0
+        llm_handler.COST_TRACKER.out_tokens_hourly = 0
+        llm_handler.COST_TRACKER.total_in_tokens = 0
+        llm_handler.COST_TRACKER.total_out_tokens = 0
+        llm_handler.COST_TRACKER.total_cost = 0.0
+
+    def tearDown(self):
+        llm_handler.LLM_CHAIN = self.orig_chain
+        if self.orig_prompt is None:
+            delattr(llm_handler, "PROMPT")
+        else:
+            llm_handler.PROMPT = self.orig_prompt
+        llm_handler.CACHE.clear()
+        llm_handler.COST_TRACKER.cost_hourly = 0.0
+        llm_handler.COST_TRACKER.in_tokens_hourly = 0
+        llm_handler.COST_TRACKER.out_tokens_hourly = 0
+        llm_handler.COST_TRACKER.total_in_tokens = 0
+        llm_handler.COST_TRACKER.total_out_tokens = 0
+        llm_handler.COST_TRACKER.total_cost = 0.0
+
+    def test_cache_hit(self):
+        alert = {"a": 1}
+        ex = []
+        key = json.dumps(alert, sort_keys=True, ensure_ascii=False) + "|" + json.dumps(ex, sort_keys=True, ensure_ascii=False)
+        llm_handler.CACHE.put(key, {"cached": True})
+        res = llm_handler.llm_analyse([{"alert": alert, "examples": ex}])
+        self.assertEqual(res, [{"cached": True}])
+        llm_handler.LLM_CHAIN.batch.assert_not_called()
+
+    def test_budget_limit(self):
+        llm_handler.COST_TRACKER.cost_hourly = config.MAX_HOURLY_COST_USD
+        res = llm_handler.llm_analyse([{"alert": {"x": 1}, "examples": []}])
+        self.assertEqual(res[0]["reason"], "Budget limit reached")
+        llm_handler.LLM_CHAIN.batch.assert_not_called()
+
+    def test_success_and_error(self):
+        llm_handler.LLM_CHAIN.batch.side_effect = [
+            ["{\"is_attack\": false}"]
+        ]
+        res = llm_handler.llm_analyse([{"alert": {"x": 1}, "examples": []}])
+        self.assertFalse(res[0]["is_attack"])
+        llm_handler.LLM_CHAIN.batch.assert_called_once()
+
+        llm_handler.LLM_CHAIN.batch.reset_mock(side_effect=True)
+        llm_handler.LLM_CHAIN.batch.side_effect = Exception("boom")
+        res = llm_handler.llm_analyse([{"alert": {"y": 2}, "examples": []}])
+        self.assertEqual(res[0]["attack_type"], "LLM API Error")
+        llm_handler.LLM_CHAIN.batch.assert_called_once()

--- a/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/tests/test_wazuh_api.py
+++ b/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/tests/test_wazuh_api.py
@@ -1,0 +1,57 @@
+import unittest
+from unittest.mock import patch, Mock
+
+from lms_log_analyzer.src import wazuh_api
+from lms_log_analyzer import config
+
+class TestWazuhAPI(unittest.TestCase):
+    def setUp(self):
+        self.orig_enabled = config.WAZUH_ENABLED
+        self.orig_url = config.WAZUH_API_URL
+        self.orig_user = config.WAZUH_API_USER
+        self.orig_pw = config.WAZUH_API_PASSWORD
+        config.WAZUH_API_URL = "http://wazuh"
+        config.WAZUH_API_USER = "user"
+        config.WAZUH_API_PASSWORD = "pass"
+        config.WAZUH_ENABLED = True
+        wazuh_api._TOKEN = None
+
+    def tearDown(self):
+        config.WAZUH_ENABLED = self.orig_enabled
+        config.WAZUH_API_URL = self.orig_url
+        config.WAZUH_API_USER = self.orig_user
+        config.WAZUH_API_PASSWORD = self.orig_pw
+        wazuh_api._TOKEN = None
+
+    @patch("lms_log_analyzer.src.wazuh_api.requests.post")
+    @patch("lms_log_analyzer.src.wazuh_api.requests.get")
+    def test_auth_retry_and_parse(self, mock_get, mock_post):
+        auth1 = Mock(status_code=200)
+        auth1.json.return_value = {"data": {"token": "t1"}}
+        auth1.raise_for_status = Mock()
+        auth2 = Mock(status_code=200)
+        auth2.json.return_value = {"data": {"token": "t2"}}
+        auth2.raise_for_status = Mock()
+        mock_get.side_effect = [auth1, auth2]
+
+        post1 = Mock(status_code=401)
+        post1.raise_for_status = Mock()
+        post2 = Mock(status_code=200)
+        post2.json.return_value = {"data": {"alerts": [{"foo": "bar"}]}}
+        post2.raise_for_status = Mock()
+        mock_post.side_effect = [post1, post2]
+
+        alert = wazuh_api.get_alert("logline")
+        self.assertEqual(alert["foo"], "bar")
+        self.assertEqual(alert["original_log"], "logline")
+        self.assertEqual(mock_get.call_count, 2)
+        self.assertEqual(mock_post.call_count, 2)
+
+    def test_wazuh_disabled(self):
+        config.WAZUH_ENABLED = False
+        lines = ["a", "b"]
+        expected = [
+            {"line": "a", "alert": {"original_log": "a"}},
+            {"line": "b", "alert": {"original_log": "b"}},
+        ]
+        self.assertEqual(wazuh_api.filter_logs(lines), expected)


### PR DESCRIPTION
## Summary
- add unit tests for Wazuh API token retry and disabled mode
- add unit tests for llm_handler cache, budget limit and success/error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68496c98d3cc8320a860be9e1c33b330