### PR TITLE
Update Wazuh consumer and README

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,8 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install flake8 pytest requests
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/llm_handler.py
+++ b/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/llm_handler.py
@@ -182,7 +182,11 @@ def llm_analyse(alerts: List[Dict[str, Any]]) -> List[Optional[dict]]:
         for start in range(0, len(batch_inputs), config.BATCH_SIZE):
             chunk = batch_inputs[start : start + config.BATCH_SIZE]
             chunk_indices = indices_to_query[start : start + config.BATCH_SIZE]
-            responses = LLM_CHAIN.batch(chunk, config={"max_concurrency": 5})  # type: ignore
+            responses = retry_with_backoff(
+                LLM_CHAIN.batch,
+                chunk,
+                config={"max_concurrency": 5},
+            )  # type: ignore
             for i, resp in enumerate(responses):
                 orig_idx = chunk_indices[i]
                 text = resp.content if hasattr(resp, "content") else resp


### PR DESCRIPTION
## Summary
- read Wazuh alerts from file or HTTP endpoint with retry and Chinese comments
- retry Gemini batch calls
- install minimal dependencies in GitHub Actions
- document new alert workflow and env vars

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849727fcb0c8320af149db6bcc475e2