### PR TITLE
Implement summary and update tests

### DIFF
--- a/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/llm_handler.py
+++ b/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/llm_handler.py
@@ -129,6 +129,19 @@ class LLMCostTracker:
 COST_TRACKER = LLMCostTracker()
 
 
+def _summarize_examples(examples: List[Dict[str, Any]]) -> List[str]:
+    """Return one-line summaries for historical examples."""
+
+    summaries = []
+    for ex in examples:
+        log = str(ex.get("log", "")).replace("\n", " ")
+        analysis = ex.get("analysis", {})
+        attack_type = analysis.get("attack_type", "")
+        reason = analysis.get("reason", "")
+        summaries.append(f"{log} | {attack_type} | {reason}".strip())
+    return summaries
+
+
 def llm_analyse(alerts: List[Dict[str, Any]]) -> List[Optional[dict]]:
     """使用 LLM 分析告警並回傳 JSON 結果
 
@@ -147,7 +160,7 @@ def llm_analyse(alerts: List[Dict[str, Any]]) -> List[Optional[dict]]:
 
     for idx, item in enumerate(alerts):
         alert = item.get("alert", item)
-        examples = item.get("examples", [])
+        examples = _summarize_examples(item.get("examples", []))
         alert_json = json.dumps(alert, ensure_ascii=False, sort_keys=True)
         examples_json = json.dumps(examples, ensure_ascii=False, sort_keys=True)
         cache_key = alert_json + "|" + examples_json
@@ -192,7 +205,7 @@ def llm_analyse(alerts: List[Dict[str, Any]]) -> List[Optional[dict]]:
                 text = resp.content if hasattr(resp, "content") else resp
                 item = alerts[orig_idx]
                 alert = item.get("alert", item)
-                examples = item.get("examples", [])
+                examples = _summarize_examples(item.get("examples", []))
                 alert_json = json.dumps(alert, ensure_ascii=False, sort_keys=True)
                 examples_json = json.dumps(examples, ensure_ascii=False, sort_keys=True)
                 cache_key = alert_json + "|" + examples_json

--- a/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/wazuh_api.py
+++ b/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/wazuh_api.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
-"""整合 Wazuh API，用於在送往 LLM 前過濾日誌"""
+"""Wazuh API utility
+
+This module offers a simple wrapper around the Wazuh logtest endpoint.
+It is handy for ad-hoc log checks but is **not** used by the regular
+batch-processing pipeline.
+"""
 
 import logging
 from typing import Dict, List, Optional
@@ -88,15 +93,3 @@ def get_alert(line: str) -> Optional[Dict[str, any]]:
         return None
 
 
-def filter_logs(lines: List[str]) -> List[Dict[str, any]]:
-    """回傳觸發告警的日誌行及其告警內容"""
-
-    if not config.WAZUH_ENABLED:
-        return [{"line": ln, "alert": {"original_log": ln}} for ln in lines]
-    # 逐行檢查並蒐集產生告警的項目
-    suspicious: List[Dict[str, any]] = []
-    for ln in lines:
-        alert = get_alert(ln)
-        if alert:
-            suspicious.append({"line": ln, "alert": alert})
-    return suspicious

--- a/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/wazuh_consumer.py
+++ b/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/wazuh_consumer.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
-"""從預先產生的檔案或 HTTP 端點讀取 Wazuh 告警"""
+"""Production Wazuh alert consumer
+
+This module reads alerts from files or an HTTP endpoint and is the
+recommended way to feed Wazuh data into the batch processing flow.
+"""
 
 import json
 import logging

--- a/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/tests/test_llm_handler.py
+++ b/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/tests/test_llm_handler.py
@@ -1,1 +1,55 @@
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from lms_log_analyzer.src import llm_handler
+from lms_log_analyzer.src.utils import LRUCache
+
+
+class DummyPrompt:
+    def format(self, **kwargs):
+        return "dummy"
+
+
+class LLMHandlerTest(unittest.TestCase):
+    def setUp(self):
+        self.orig_chain = llm_handler.LLM_CHAIN
+        self.orig_prompt = getattr(llm_handler, "PROMPT", None)
+        llm_handler.LLM_CHAIN = MagicMock()
+        llm_handler.LLM_CHAIN.batch.return_value = [
+            json.dumps({"is_attack": False})
+        ]
+        llm_handler.PROMPT = DummyPrompt()
+        llm_handler.CACHE = LRUCache(10)
+
+    def tearDown(self):
+        llm_handler.LLM_CHAIN = self.orig_chain
+        if self.orig_prompt is not None:
+            llm_handler.PROMPT = self.orig_prompt
+
+    def test_llm_analyse_caches_and_summarizes(self):
+        example = {
+            "log": "bad log",
+            "analysis": {"attack_type": "sql", "reason": "r"},
+        }
+        alerts = [{"alert": {"id": 1}, "examples": [example]}]
+
+        with patch("lms_log_analyzer.src.llm_handler.retry_with_backoff", side_effect=lambda f, *a, **k: f(*a, **k)):
+            result1 = llm_handler.llm_analyse(alerts)
+
+        llm_handler.LLM_CHAIN.batch.assert_called_once()
+        sent = llm_handler.LLM_CHAIN.batch.call_args.args[0][0]["examples_json"]
+        summaries = json.loads(sent)
+        self.assertIn("bad log", summaries[0])
+
+        llm_handler.LLM_CHAIN.batch.reset_mock()
+        with patch("lms_log_analyzer.src.llm_handler.retry_with_backoff", side_effect=lambda f, *a, **k: f(*a, **k)):
+            result2 = llm_handler.llm_analyse(alerts)
+
+        llm_handler.LLM_CHAIN.batch.assert_not_called()
+        self.assertEqual(result1, result2)
+
+
+if __name__ == "__main__":
+    unittest.main()
 

--- a/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/tests/test_wazuh_api.py
+++ b/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/tests/test_wazuh_api.py
@@ -49,9 +49,4 @@ class TestWazuhAPI(unittest.TestCase):
 
     def test_wazuh_disabled(self):
         config.WAZUH_ENABLED = False
-        lines = ["a", "b"]
-        expected = [
-            {"line": "a", "alert": {"original_log": "a"}},
-            {"line": "b", "alert": {"original_log": "b"}},
-        ]
-        self.assertEqual(wazuh_api.filter_logs(lines), expected)
+        self.assertEqual(wazuh_api.get_alert("line1"), {"original_log": "line1"})


### PR DESCRIPTION
## Summary
- add helper to summarize historical examples before prompting
- clarify wazuh consumer vs API usage and remove unused filter
- implement tests for llm_handler with mocked LLM
- adjust existing Wazuh tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68497602c8408320a00d2755881fa3cb