### PR TITLE
Add docstrings linking Wazuh modules

### DIFF
--- a/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/wazuh_api.py
+++ b/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/wazuh_api.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 """Wazuh API utility
 
-This module offers a simple wrapper around the Wazuh logtest endpoint.
+This module offers a simple wrapper around the Wazuh ``logtest`` endpoint.
 It is handy for ad-hoc log checks but is **not** used by the regular
 batch-processing pipeline.
+
+``wazuh_consumer.py`` provides the production mechanism for ingesting Wazuh
+alerts. Use this ``wazuh_api`` module only when you need to query the API
+directly for a single log line.
 """
 
 import logging

--- a/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/wazuh_consumer.py
+++ b/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/wazuh_consumer.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 
 This module reads alerts from files or an HTTP endpoint and is the
 recommended way to feed Wazuh data into the batch processing flow.
+
+It complements :mod:`wazuh_api`, which offers a lightweight wrapper around the
+Wazuh ``logtest`` endpoint for ad-hoc queries.
 """
 
 import json


### PR DESCRIPTION
## Summary
- explain `wazuh_api.py` usage and reference `wazuh_consumer.py`
- explain `wazuh_consumer.py` and its relation to `wazuh_api.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ae0ef18c8320adbaa5d55138f1b3