### PR TITLE
Fix string literal and alerts variable

### DIFF
--- a/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/wazuh_api.py
+++ b/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/wazuh_api.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
-"""Wazuh API 工具模組
-
+"""Wazuh API 工具模組."""
 
 
 import logging

--- a/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/wazuh_consumer.py
+++ b/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/wazuh_consumer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-"""Wazuh 告警消費者（正式環境用）
+"""Wazuh 告警消費者（正式環境用）。"""
 
 
 import json

--- a/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/tests/test_llm_handler.py
+++ b/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/tests/test_llm_handler.py
@@ -60,6 +60,7 @@ class LLMHandlerTest(unittest.TestCase):
     def test_llm_analyse_budget_limit(self):
         llm_handler.COST_TRACKER.get_hourly_cost = MagicMock(return_value=llm_handler.config.MAX_HOURLY_COST_USD)
 
+        alerts = [{"alert": {"rule": {"id": 1}}, "examples": []}]
         with patch("lms_log_analyzer.src.llm_handler.retry_with_backoff", side_effect=lambda f,*a,**k: f(*a, **k)):
             result = llm_handler.llm_analyse(alerts)
         llm_handler.LLM_CHAIN.batch.assert_not_called()
@@ -68,6 +69,7 @@ class LLMHandlerTest(unittest.TestCase):
     def test_llm_analyse_disabled(self):
         llm_handler.LLM_CHAIN = None
 
+        alerts = [{"alert": {"rule": {"id": 1}}, "examples": []}]
         result = llm_handler.llm_analyse(alerts)
         self.assertEqual(result, [None])
 


### PR DESCRIPTION
## Summary
- close un-terminated docstrings
- define missing `alerts` variable in tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a4faa80d88320a45ff9c2c7589515